### PR TITLE
Corrected link to SourceTree so that SourceTree is not needed in PATH

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -3,7 +3,7 @@ const open = require('open')
 
 async function openInSourceTree () {
     const { rootPath } = vscode.workspace
-    open(rootPath, 'SourceTree')
+    open(rootPath, '%LOCALAPPDATA%\\SourceTree\\SourceTree.exe')
 }
 
 function activate(context) {


### PR DESCRIPTION
There is still another part - but this is the first part of the fix,

The second part is about passing a "-f" flag along with SourceTree to node-open