### PR TITLE
 Included support for Mercurial repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Adds a command for opening the current project in [SourceTree](https://www.sourcetreeapp.com/).
 
-- If there is a file open, it will open the git repo for that file
+- If there is a file open, it will open the Git or Mercurial repo for that file
 - If it is a workspace, it will ask you what folder you would like to open
-- It will automatically find the best git repo to open
+- It will automatically find the best Git repo to open
 
 ## Install
 

--- a/extension.js
+++ b/extension.js
@@ -15,11 +15,11 @@ async function askUserForPath(workspaceFolders)
     }
 }
 
-function findGitRoot(filepath) {
+function findRepoRoot(filepath) {
     let startingPath = fs.lstatSync(filepath).isDirectory() ? filepath : path.dirname(filepath)
 
     return findRoot(startingPath, function (dir) {
-        return fs.existsSync(path.resolve(dir, '.git'))
+        return fs.existsSync(path.resolve(dir, '.git')) || fs.existsSync(path.resolve(dir, '.hg'))
     })
 }
 
@@ -45,13 +45,13 @@ async function openInSourceTree () {
 
         if (! relevantPath) return
 
-        const gitPath = await findGitRoot(relevantPath)
+        const repoPath = await findRepoRoot(relevantPath)
 
-        await open(gitPath, { app: 'SourceTree' })
+        await open(repoPath, { app: 'SourceTree' })
     }
     catch (err) {
         console.error(err)
-        vscode.window.showErrorMessage('No git repo found.')
+        vscode.window.showErrorMessage('No Git or Mercurial repo found.')
     }
 }
 


### PR DESCRIPTION
Included the detection of .hg folders. This is the folder used by Mercurial, the other type of version control that Sourcetree can use apart from Git.